### PR TITLE
fix(github): version trigger

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,9 +1,7 @@
 name: Bump version
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
     paths-ignore:


### PR DESCRIPTION
for https://github.com/rees46/development/issues/2715

- меняю триггер на push, reusable-version работает только с пушем