### PR TITLE
fix(github): workflow naming

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-merge-commit:
-    uses: rees46/workflow/.github/workflows/reusable-validate-commit.yaml@master
+    uses: rees46/workflow/.github/workflows/reusable-check-commit-message.yaml@master
 
   bump-version:
     needs: validate-merge-commit


### PR DESCRIPTION
for https://github.com/rees46/development/issues/2976

- меняли название экшена. после последнего мерджа в текущую репу